### PR TITLE
refactor: OpenCell.shadyCellsの実装をmapから[]Positionsにした

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/inahym196/bomb
 go 1.23.5
 
 require github.com/MakeNowJust/heredoc v1.0.0
+
+require (
+	github.com/aclements/go-moremath v0.0.0-20241023150245-c8bbc672ef66 // indirect
+	golang.org/x/perf v0.0.0-20250305200902-02a15fd477ba // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/aclements/go-moremath v0.0.0-20241023150245-c8bbc672ef66 h1:siNQlUMcFUDZWCOt0p+RHl7et5Nnwwyq/sFZmr4iG1I=
+github.com/aclements/go-moremath v0.0.0-20241023150245-c8bbc672ef66/go.mod h1:FDw7qicTbJ1y1SZcNnOvym2BogPdC3lY9Z1iUM4MVhw=
+golang.org/x/perf v0.0.0-20250305200902-02a15fd477ba h1:0iM7SkkyXtZKGBWfn+ka1Rj6VOCRyFMkEHaCWsaR7no=
+golang.org/x/perf v0.0.0-20250305200902-02a15fd477ba/go.mod h1:YEhzh+7vn0fUjydWEf27T4XWyeMDdRK44swFIgYh/nY=

--- a/internal/solver/domain/cell_test.go
+++ b/internal/solver/domain/cell_test.go
@@ -44,10 +44,10 @@ func TestNewSolverCells(t *testing.T) {
 	}
 	want := map[shared.Position]OpenCell{
 		shared.NewPosition(0, 1): {
-			map[shared.Position]struct{}{shared.NewPosition(0, 0): {}, shared.NewPosition(1, 0): {}}, 1,
+			[]shared.Position{shared.NewPosition(0, 0), shared.NewPosition(1, 0)}, 1,
 		},
 		shared.NewPosition(2, 1): {
-			map[shared.Position]struct{}{shared.NewPosition(1, 0): {}, shared.NewPosition(2, 0): {}}, 1,
+			[]shared.Position{shared.NewPosition(1, 0), shared.NewPosition(2, 0)}, 1,
 		},
 	}
 	if got := NewSolverCells(cells, bombCounts); !reflect.DeepEqual(got, want) {

--- a/internal/solver/domain/solver.go
+++ b/internal/solver/domain/solver.go
@@ -68,7 +68,7 @@ func (t theorem1) GetDescription() string {
 func (t theorem1) Apply(cells map[shared.Position]OpenCell) Solution {
 	poss := make([]shared.Position, 0, len(cells)/2)
 	for _, opencell := range cells {
-		shadyCells := opencell.GetShadyCellKeys()
+		shadyCells := opencell.GetShadyPositions()
 		if len(shadyCells) <= opencell.GetBombCount() {
 			poss = append(poss, shadyCells...)
 		}


### PR DESCRIPTION
```bash
❯ benchstat before.out after.out                                                             
goos: darwin
goarch: amd64
pkg: github.com/inahym196/bomb/internal/solver/domain
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
                 │  before.out  │              after.out               │
                 │    sec/op    │    sec/op     vs base                │
NewSolverCells-8   451.6n ± 10%   344.1n ± 35%  -23.80% (p=0.009 n=10)

                 │ before.out │           after.out            │
                 │    B/op    │    B/op     vs base            │
NewSolverCells-8   720.0 ± 0%   720.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                 │ before.out │             after.out              │
                 │ allocs/op  │ allocs/op   vs base                │
NewSolverCells-8   6.000 ± 0%   4.000 ± 0%  -33.33% (p=0.000 n=10)
```