### PR TITLE
fix: rename check/uncheck to flag/unflag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Available Commands:
   > start custom <width> <totalBomb>    Start Game, Set Custom width and totalBomb
   > show                                Show board
   > open <row: int> <col: alpha>        Open cell
-  > check/uncheck <row> <col>           Check/UnCheck cell
+  > flag/unflag <row> <col>             Flag/UnFlag cell
   > help                                Show this help message
   > exit                                Exit the program
 
@@ -52,7 +52,7 @@ gameState: Playing
  7 □ □ □ □ 2 1 2 □ □
  8 □ □ □ □ □ □ □ □ □
 
-Enter command> check 2 A
+Enter command> flag 2 A
 gameState: Playing
    A B C D E F G H I
  0 0 0 0 0 0 1 □ 1 0

--- a/internal/controller/cli_controller.go
+++ b/internal/controller/cli_controller.go
@@ -102,28 +102,28 @@ func (c *CLIController) Run() {
 			}
 			fmt.Printf("gameState: %s\n", stateToStr(result.State))
 			fmt.Println(c.parseGame(result.GameDTO))
-		case "check":
-			row, col, err := c.parseCheckArgs(words)
+		case "flag":
+			row, col, err := c.parseFlagArgs(words)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
 			}
-			param := interactor.CheckCellParam{Pos: shared.NewPosition(col, row)}
-			result, err := c.gi.CheckCell(param)
+			param := interactor.FlagCellParam{Pos: shared.NewPosition(col, row)}
+			result, err := c.gi.FlagCell(param)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
 			}
 			fmt.Printf("gameState: %s\n", stateToStr(result.State))
 			fmt.Println(c.parseGame(result.GameDTO))
-		case "uncheck":
-			row, col, err := c.parseUnCheckArgs(words)
+		case "unflag":
+			row, col, err := c.parseUnFlagArgs(words)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
 			}
-			param := interactor.UnCheckCellParam{Pos: shared.NewPosition(col, row)}
-			result, err := c.gi.UnCheckCell(param)
+			param := interactor.UnFlagCellParam{Pos: shared.NewPosition(col, row)}
+			result, err := c.gi.UnFlagCell(param)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
@@ -140,7 +140,7 @@ func (c *CLIController) Run() {
 			  > start custom <width> <totalBomb>    Start Game, Set Custom width and totalBomb
 			  > show                                Show board
 			  > open <row: int> <col: alpha>        Open cell
-			  > check/uncheck <row> <col>           Check/UnCheck cell
+			  > flag/unflag <row> <col>             Flag/UnFlag cell
 			  > help                                Show this help message
 			  > exit                                Exit the program
 			`))

--- a/internal/controller/parse_args.go
+++ b/internal/controller/parse_args.go
@@ -68,7 +68,7 @@ func (c *CLIController) parseOpenArgs(words []string) (row, col int, err error) 
 	return row, col, nil
 }
 
-func (c *CLIController) parseCheckArgs(words []string) (row, col int, err error) {
+func (c *CLIController) parseFlagArgs(words []string) (row, col int, err error) {
 	if len(words) != 3 {
 		return 0, 0, fmt.Errorf("引数の数が不正です. \"help\"コマンドを確認してください")
 	}
@@ -83,7 +83,7 @@ func (c *CLIController) parseCheckArgs(words []string) (row, col int, err error)
 	return row, col, nil
 }
 
-func (c *CLIController) parseUnCheckArgs(words []string) (row, col int, err error) {
+func (c *CLIController) parseUnFlagArgs(words []string) (row, col int, err error) {
 	if len(words) != 3 {
 		return 0, 0, fmt.Errorf("引数の数が不正です. \"help\"コマンドを確認してください")
 	}

--- a/internal/game/interactor/game_interactor.go
+++ b/internal/game/interactor/game_interactor.go
@@ -93,46 +93,46 @@ func (gi *GameInteractor) OpenCell(param OpenCellParam) (OpenCellResult, error) 
 	return OpenCellResult{toGameDTO(game)}, nil
 }
 
-type CheckCellParam struct {
+type FlagCellParam struct {
 	Pos shared.Position
 }
 
-type CheckCellResult struct {
+type FlagCellResult struct {
 	GameDTO
 }
 
-func (gi *GameInteractor) CheckCell(param CheckCellParam) (CheckCellResult, error) {
+func (gi *GameInteractor) FlagCell(param FlagCellParam) (FlagCellResult, error) {
 	game, ok := gi.game_repo.Find()
 	if !ok {
-		return CheckCellResult{}, fmt.Errorf("ゲームが初期化されていません")
+		return FlagCellResult{}, fmt.Errorf("ゲームが初期化されていません")
 	}
 	if err := game.Flag(param.Pos); err != nil {
-		return CheckCellResult{}, err
+		return FlagCellResult{}, err
 	}
 	if err := gi.game_repo.Save(game); err != nil {
-		return CheckCellResult{}, err
+		return FlagCellResult{}, err
 	}
-	return CheckCellResult{toGameDTO(game)}, nil
+	return FlagCellResult{toGameDTO(game)}, nil
 }
 
-type UnCheckCellParam struct {
+type UnFlagCellParam struct {
 	Pos shared.Position
 }
 
-type UnCheckCellResult struct {
+type UnFlagCellResult struct {
 	GameDTO
 }
 
-func (gi *GameInteractor) UnCheckCell(param UnCheckCellParam) (UnCheckCellResult, error) {
+func (gi *GameInteractor) UnFlagCell(param UnFlagCellParam) (UnFlagCellResult, error) {
 	game, ok := gi.game_repo.Find()
 	if !ok {
-		return UnCheckCellResult{}, fmt.Errorf("ゲームが初期化されていません")
+		return UnFlagCellResult{}, fmt.Errorf("ゲームが初期化されていません")
 	}
 	if err := game.UnFlag(param.Pos); err != nil {
-		return UnCheckCellResult{}, err
+		return UnFlagCellResult{}, err
 	}
 	if err := gi.game_repo.Save(game); err != nil {
-		return UnCheckCellResult{}, err
+		return UnFlagCellResult{}, err
 	}
-	return UnCheckCellResult{toGameDTO(game)}, nil
+	return UnFlagCellResult{toGameDTO(game)}, nil
 }


### PR DESCRIPTION
```bash
# before 
bomb on  main [⇣] via 🐹 v1.23.5 
❯ grep -ir check | grep -cv .git
27

# after
bomb on  15-checkuncheckからflagunflagに名称変更する via 🐹 v1.23.5 
❯ grep -ir check | grep -cv .git                         
0
```